### PR TITLE
Add support for webm files

### DIFF
--- a/main.js
+++ b/main.js
@@ -7002,7 +7002,8 @@ var AudioPlayer = class extends import_obsidian4.Plugin {
         "mp3",
         "wav",
         "ogg",
-        "flac"
+        "flac",
+        "webm"
       ];
       const link = this.app.metadataCache.getFirstLinkpathDest((0, import_obsidian4.getLinkpath)(filename), filename);
       if (!link || !allowedExtensions.includes(link.extension))

--- a/src/main.ts
+++ b/src/main.ts
@@ -79,7 +79,8 @@ export default class AudioPlayer extends Plugin {
 					"ogg",
 					"flac",
 					"mp4",
-					"m4a"
+					"m4a",
+					"webm"
 				];
 				const link = this.app.metadataCache.getFirstLinkpathDest(
 					getLinkpath(filename),


### PR DESCRIPTION
Addresses #24 #3 

My primary motivation for this feature is that Obsidian uses webm as the [voice recording](https://help.obsidian.md/Plugins/Audio+recorder) format.

I saw your concerns from #3, but the Obsidian recordings seem to work fine in my tests, and the media format for the Audio API seems to support processing audio from webm:

https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Audio_codecs