### PR TITLE
Fix file regex to support aliases

### DIFF
--- a/main.js
+++ b/main.js
@@ -27,10 +27,10 @@ __export(main_exports, {
   default: () => AudioPlayer
 });
 module.exports = __toCommonJS(main_exports);
-var import_obsidian4 = require("obsidian");
+var import_obsidian3 = require("obsidian");
 
 // src/audioPlayerRenderer.ts
-var import_obsidian3 = require("obsidian");
+var import_obsidian2 = require("obsidian");
 
 // node_modules/@vue/shared/dist/shared.esm-bundler.js
 function makeMap(str, expectsLowerCase) {
@@ -6525,8 +6525,8 @@ if (true) {
   initDev();
 }
 
-// sfc-script:/mnt/d/the-book-of-knowledge/.obsidian/plugins/obsidian-audio-player/src/components/App.vue?type=script
-var import_obsidian2 = require("obsidian");
+// sfc-script:/home/daniel/notes/obsidian/.obsidian/plugins/obsidian-audio-player/src/components/App.vue?type=script
+var import_obsidian = require("obsidian");
 
 // src/utils.ts
 function secondsToString(num) {
@@ -6541,8 +6541,7 @@ function secondsToNumber(stmp) {
   return nums[2] + nums[1] * 60 + nums[0] * 3600;
 }
 
-// sfc-script:/mnt/d/the-book-of-knowledge/.obsidian/plugins/obsidian-audio-player/src/components/AudioComment.vue?type=script
-var import_obsidian = require("obsidian");
+// sfc-script:/home/daniel/notes/obsidian/.obsidian/plugins/obsidian-audio-player/src/components/AudioComment.vue?type=script
 var AudioComment_default = defineComponent({
   name: "AudioComment",
   props: {
@@ -6556,29 +6555,20 @@ var AudioComment_default = defineComponent({
     emitRemove() {
       this.$emit("remove", this.cmt.index);
     }
-  },
-  mounted() {
-    this.button = this.$refs.remove;
-    (0, import_obsidian.setIcon)(this.button, "cross");
   }
 });
 
-// sfc-template:/mnt/d/the-book-of-knowledge/.obsidian/plugins/obsidian-audio-player/src/components/AudioComment.vue?type=template
-var _hoisted_1 = { class: "comment" };
+// sfc-template:/home/daniel/notes/obsidian/.obsidian/plugins/obsidian-audio-player/src/components/AudioComment.vue?type=template
+var _hoisted_1 = { class: "timestamp" };
 var _hoisted_2 = { class: "content" };
 function render(_ctx, _cache, $props, $setup, $data, $options) {
   var _a2, _b;
-  return openBlock(), createElementBlock("div", _hoisted_1, [
-    createBaseVNode("span", {
-      class: "timestamp",
-      onClick: _cache[0] || (_cache[0] = (...args) => _ctx.emitMovePlayhead && _ctx.emitMovePlayhead(...args))
-    }, toDisplayString((_a2 = _ctx.cmt) == null ? void 0 : _a2.timeString), 1),
-    createBaseVNode("span", _hoisted_2, toDisplayString((_b = _ctx.cmt) == null ? void 0 : _b.content), 1),
-    createBaseVNode("div", {
-      onClick: _cache[1] || (_cache[1] = (...args) => _ctx.emitRemove && _ctx.emitRemove(...args)),
-      class: "delete-comment",
-      ref: "remove"
-    }, null, 512)
+  return openBlock(), createElementBlock("div", {
+    class: "comment",
+    onClick: _cache[0] || (_cache[0] = (...args) => _ctx.emitMovePlayhead && _ctx.emitMovePlayhead(...args))
+  }, [
+    createBaseVNode("span", _hoisted_1, toDisplayString((_a2 = _ctx.cmt) == null ? void 0 : _a2.timeString), 1),
+    createBaseVNode("span", _hoisted_2, toDisplayString((_b = _ctx.cmt) == null ? void 0 : _b.content), 1)
   ]);
 }
 
@@ -6587,7 +6577,7 @@ AudioComment_default.render = render;
 AudioComment_default.__file = "src/components/AudioComment.vue";
 var AudioComment_default2 = AudioComment_default;
 
-// sfc-script:/mnt/d/the-book-of-knowledge/.obsidian/plugins/obsidian-audio-player/src/components/App.vue?type=script
+// sfc-script:/home/daniel/notes/obsidian/.obsidian/plugins/obsidian-audio-player/src/components/App.vue?type=script
 var App_default = defineComponent({
   name: "App",
   components: {
@@ -6615,6 +6605,7 @@ var App_default = defineComponent({
       showInput: false,
       newComment: "",
       comments: [],
+      activeComment: null,
       ro: ResizeObserver,
       smallSize: false
     };
@@ -6640,12 +6631,15 @@ var App_default = defineComponent({
     getParentWidth() {
       return this.mdElement.clientWidth;
     },
+    isCurrent() {
+      return this.audio.src === this.srcPath;
+    },
     onResize() {
       this.smallSize = this.$el.clientWidth < 300;
     },
     async loadFile() {
       const file = window.app.vault.getAbstractFileByPath(this.filepath);
-      if (file && file instanceof import_obsidian2.TFile) {
+      if (file && file instanceof import_obsidian.TFile) {
         if (!this.loadCache())
           this.processAudio(file.path);
         this.srcPath = window.app.vault.getResourcePath(file);
@@ -6686,17 +6680,20 @@ var App_default = defineComponent({
         this.saveCache();
       });
     },
+    showCommentInput() {
+      this.showInput = true;
+      setTimeout(() => {
+        const input = this.$refs.commentInput;
+        input.focus();
+      });
+    },
     barMouseDownHandler(i) {
       this.clickCount += 1;
       setTimeout(() => {
         this.clickCount = 0;
       }, 200);
       if (this.clickCount >= 2) {
-        this.showInput = true;
-        setTimeout(() => {
-          const input = this.$refs.commentInput;
-          input.focus();
-        });
+        this.showCommentInput();
       } else {
         let time = i / this.nSamples * this.duration;
         this.setPlayheadSecs(time);
@@ -6704,12 +6701,14 @@ var App_default = defineComponent({
     },
     setPlayheadSecs(time) {
       this.currentTime = time;
-      if (this.audio.src === this.srcPath) {
+      if (!this.isCurrent())
+        this.togglePlay();
+      if (this.isCurrent()) {
         this.audio.currentTime = time;
       }
     },
     togglePlay() {
-      if (!(this.audio.src === this.srcPath)) {
+      if (!this.isCurrent()) {
         this.audio.src = this.srcPath;
       }
       if (this.audio.paused) {
@@ -6726,11 +6725,13 @@ var App_default = defineComponent({
       }
       this.audio.addEventListener("timeupdate", this.timeUpdateHandler);
       (_a2 = this.audio) == null ? void 0 : _a2.play();
+      this.playing = true;
       this.setBtnIcon("pause");
     },
     pause() {
       var _a2;
       (_a2 = this.audio) == null ? void 0 : _a2.pause();
+      this.playing = false;
       this.setBtnIcon("play");
     },
     globalPause() {
@@ -6739,12 +6740,23 @@ var App_default = defineComponent({
     },
     timeUpdateHandler() {
       var _a2;
-      if (this.audio.src === this.srcPath)
+      if (this.isCurrent()) {
         this.currentTime = (_a2 = this.audio) == null ? void 0 : _a2.currentTime;
+        const nextCommencts = this.commentsSorted.filter((x) => {
+          var _a3;
+          return ((_a3 = this.audio) == null ? void 0 : _a3.currentTime) >= x.timeNumber;
+        });
+        if (nextCommencts.length == 1) {
+          this.activeComment = nextCommencts[0];
+        }
+        if (nextCommencts.length > 1) {
+          this.activeComment = nextCommencts[nextCommencts.length - 1];
+        }
+      }
     },
     setBtnIcon(icon) {
-      (0, import_obsidian2.setIcon)(this.button, icon);
-      (0, import_obsidian2.setIcon)(this.button1, icon);
+      (0, import_obsidian.setIcon)(this.button, icon);
+      (0, import_obsidian.setIcon)(this.button1, icon);
     },
     addComment() {
       if (this.newComment.length == 0)
@@ -6790,10 +6802,12 @@ var App_default = defineComponent({
       this.setBtnIcon("play");
     });
     document.addEventListener("allresume", () => {
-      console.log("test");
-      if (this.audio.src === this.srcPath) {
+      if (this.isCurrent())
         this.setBtnIcon("pause");
-      }
+    });
+    document.addEventListener("addcomment", () => {
+      if (this.isCurrent())
+        this.showCommentInput();
     });
     this.audio.addEventListener("ended", () => {
       if (this.audio.src === this.srcPath)
@@ -6818,7 +6832,7 @@ var App_default = defineComponent({
   }
 });
 
-// sfc-template:/mnt/d/the-book-of-knowledge/.obsidian/plugins/obsidian-audio-player/src/components/App.vue?type=template
+// sfc-template:/home/daniel/notes/obsidian/.obsidian/plugins/obsidian-audio-player/src/components/App.vue?type=template
 var _hoisted_12 = {
   class: "audio-player-ui",
   tabindex: "0"
@@ -6929,11 +6943,12 @@ function render2(_ctx, _cache, $props, $setup, $data, $options) {
     createBaseVNode("div", _hoisted_122, [
       (openBlock(true), createElementBlock(Fragment, null, renderList(_ctx.commentsSorted, (cmt) => {
         return openBlock(), createBlock(_component_AudioCommentVue, {
+          class: normalizeClass({ "active-comment": cmt == _ctx.activeComment }),
           onMovePlayhead: _ctx.setPlayheadSecs,
           onRemove: _ctx.removeComment,
           cmt,
           key: cmt.timeString
-        }, null, 8, ["onMovePlayhead", "onRemove", "cmt"]);
+        }, null, 8, ["class", "onMovePlayhead", "onRemove", "cmt"]);
       }), 128))
     ])
   ]);
@@ -6945,7 +6960,7 @@ App_default.__file = "src/components/App.vue";
 var App_default2 = App_default;
 
 // src/audioPlayerRenderer.ts
-var AudioPlayerRenderer = class extends import_obsidian3.MarkdownRenderChild {
+var AudioPlayerRenderer = class extends import_obsidian2.MarkdownRenderChild {
   constructor(containerEl, options) {
     super(containerEl);
     this.options = options;
@@ -6965,7 +6980,7 @@ var AudioPlayerRenderer = class extends import_obsidian3.MarkdownRenderChild {
 };
 
 // src/main.ts
-var AudioPlayer = class extends import_obsidian4.Plugin {
+var AudioPlayer = class extends import_obsidian3.Plugin {
   async onload() {
     const player = document.createElement("audio");
     player.volume = 0.5;
@@ -6975,7 +6990,7 @@ var AudioPlayer = class extends import_obsidian4.Plugin {
       id: "pause-audio",
       name: "Pause Audio",
       callback: () => {
-        new import_obsidian4.Notice("Audio paused");
+        new import_obsidian3.Notice("Audio paused");
         const ev = new Event("allpause");
         document.dispatchEvent(ev);
         player.pause();
@@ -6985,28 +7000,58 @@ var AudioPlayer = class extends import_obsidian4.Plugin {
       id: "resume-audio",
       name: "Resume Audio",
       callback: () => {
-        new import_obsidian4.Notice("Audio resumed");
+        new import_obsidian3.Notice("Audio resumed");
         const ev = new Event("allresume");
         document.dispatchEvent(ev);
         if (player.src)
           player.play();
       }
     });
+    this.addCommand({
+      id: "add-audio-comment",
+      name: "Add bookmark",
+      callback: () => {
+        const ev = new Event("addcomment");
+        document.dispatchEvent(ev);
+      }
+    });
+    this.addCommand({
+      id: "audio-forward-5s",
+      name: "+5 sec",
+      callback: () => {
+        if (player.src)
+          player.currentTime += 5;
+      }
+    });
+    this.addCommand({
+      id: "audio-back-5s",
+      name: "-5 sec",
+      callback: () => {
+        if (player.src)
+          player.currentTime -= 5;
+      }
+    });
     this.registerMarkdownCodeBlockProcessor("audio-player", (source, el, ctx) => {
-      var _a2;
-      const re = /\[\[(.+)\]\]/g;
+      var _a2, _b;
+      const re = /\[\[(.+?)(?:\|(.*))?\]\]/g;
       const filename = (_a2 = re.exec(source)) == null ? void 0 : _a2.at(1);
+      const alias = (_b = re.exec(source)) == null ? void 0 : _b.at(2);
       if (!filename)
         return;
       const allowedExtensions = [
         "mp3",
         "wav",
         "ogg",
-        "flac"
+        "flac",
+        "mp4",
+        "m4a"
       ];
-      const link = this.app.metadataCache.getFirstLinkpathDest((0, import_obsidian4.getLinkpath)(filename), filename);
-      if (!link || !allowedExtensions.includes(link.extension))
+      const link = this.app.metadataCache.getFirstLinkpathDest((0, import_obsidian3.getLinkpath)(filename), filename);
+      console.log(link);
+      if (!link || !allowedExtensions.includes(link.extension)) {
+        console.log("invalid link or extension");
         return;
+      }
       const container = el.createDiv();
       container.classList.add("base-container");
       ctx.addChild(new AudioPlayerRenderer(el, {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "obsidian-audio-player",
 	"name": "Audio Player",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"minAppVersion": "0.15.0",
 	"description": "Audio player with background playback, bookmarks and wave visualiser instead of the default html5 audio",
 	"author": "noones img",

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,8 +69,9 @@ export default class AudioPlayer extends Plugin {
 				ctx: MarkdownPostProcessorContext
 			) => {
 				// parse file name
-				const re = /\[\[(.+)\]\]/g;
+				const re = /\[\[(.+?)(?:\|(.*))?\]\]/g;
 				const filename = re.exec(source)?.at(1);
+				const alias = re.exec(source)?.at(2);
 				if (!filename) return;
 
 				const allowedExtensions = [
@@ -85,8 +86,11 @@ export default class AudioPlayer extends Plugin {
 					getLinkpath(filename),
 					filename
 				);
-				if (!link || !allowedExtensions.includes(link.extension))
+				console.log(link)
+				if (!link || !allowedExtensions.includes(link.extension)) {
+					console.log("invalid link or extension")
 					return;
+				}
 
 				// create root $el
 				const container = el.createDiv();


### PR DESCRIPTION
Hi @noonesimg ,

Apologies for the half-baked PR -- I'm not quite sure how your build process works, but it seems like you might have been building `main.js` locally and then pushing it up? This PR includes updates to main.js, but you probably just want to scrap the PR and make the one-line change yourself.

The main change is just to improve the markdown file link regex to support aliases.
```
const re = /\[\[(.+?)(?:\|(.*))?\]\]/g;
const filename = re.exec(source)?.at(1);
const alias = re.exec(source)?.at(2);
```

Previously a link like this would break:
```
[[Audio/Audio Recordings/2023-10-24_09-26-28.m4a|2023-10-24_09-26-28]]
```
This was frustrating because the above link was auto-completed by obsidian.